### PR TITLE
Added support for net462 for better compatiblity

### DIFF
--- a/NLog.Layouts.ClefJsonLayout.csproj
+++ b/NLog.Layouts.ClefJsonLayout.csproj
@@ -1,10 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <Description>An NLog layout that writes JSON in Compact Log Event Format (CLEF) that is compatible with Seq. Based on NLog.Targets.Seq code.</Description>
         <Authors>Datalust;Contributors;Pavel Mikhaylov</Authors>
         <Version>1.0.4</Version>
-        <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+        <TargetFrameworks>net462;netstandard2.0;net6.0;net8.0</TargetFrameworks>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <PackageTags>seq;nlog;clef;json</PackageTags>
         <PackageProjectUrl>https://github.com/paulem/nlog-layouts-clef</PackageProjectUrl>
@@ -22,7 +22,7 @@
         <PackageReference Include="NLog" Version="5.2.5"/>
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net462' ">
         <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0"/>
     </ItemGroup>
 


### PR DESCRIPTION
.NET Framework 462 can use NetStandard2.0, but sometimes gives build/runtime noise. Better with direct support.